### PR TITLE
Allow `Provider` to be passed multiple children

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ import {observer} from "mobx-preact";
 ### `Provider` and `inject`
 
 `Provider` is a component that can pass stores (or other stuff) using Preact's context mechanism to child components.
-This is useful if you have things that you don't want to pass through multiple layers of components explicitly.
+This is useful if you have things that you don't want to pass through multiple layers of components explicitly. If
+`Provider` has multiple immediate children, they will be wrapped with a `div` element.
 
 `inject` can be used to pick up those stores. It is a higher order component that takes a list of strings and makes those stores available to the wrapped component.
 
@@ -167,9 +168,7 @@ class MessageList extends Component {
       <Message text={message.text} />
     );
     return <Provider color="red">
-        <div>
-            {children}
-        </div>
+      {children}
     </Provider>;
   }
 }

--- a/sample/sample.js
+++ b/sample/sample.js
@@ -13,6 +13,7 @@ class App extends Component {
     render() {
         return (
             <Provider store={store}>
+                <CounterStateless />
                 <Inbetween>
                     <CounterComp />
                     <CounterConnect />
@@ -54,7 +55,7 @@ class CounterConnect extends Component {
     }
 }
 
-const CounterStateless = inject('store')(observer(function({ store}) {
+const CounterStateless = inject('store')(observer(function({ store }) {
     return <p>Stateless count is { store.count }</p>;
 }));
 

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -1,5 +1,4 @@
-import { Component } from 'preact';
-import { childrenOnly } from './utils/utils';
+import { h, Component } from 'preact';
 
 const specialReactKeys = { children: true, key: true, ref: true };
 
@@ -7,7 +6,7 @@ const logger = console; // eslint-disable-line no-console
 
 export class Provider extends Component {
     render({ children }) {
-        return childrenOnly(children);
+        return children.length > 1 ? <div> { children } </div>  : children[0];
     }
 
     getChildContext() {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -6,15 +6,6 @@ export function isStateless(component) {
     return !(component.prototype && component.prototype.render) && !Component.isPrototypeOf(component);
 }
 
-// adapted from https://github.com/developit/preact-compat/blob/3.17.0/src/index.js#L204
-export function childrenOnly(children) {
-    children = children == null ? [] : [].concat(children);
-    if (children.length !== 1) {
-        throw new Error('Children.only() expects only one child.');
-    }
-    return children[0];
-}
-
 export function makeDisplayName(component, { prefix = '', suffix = ''} = {}) {
     let displayName =
         (component.displayName || component.name || (component.constructor && component.constructor.name) || '<component>');

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -176,4 +176,23 @@ describe('observer based context', () => {
         expect(msg).toBe(null);
         console.warn = baseWarn;
     });
+
+    test('Provider supports multiple children', () => {
+        const store = {
+            B: 'foo',
+            C: 'bar',
+        };
+
+        const B = inject('store')(({ store }) => <div class="b">{ store.B }</div>);
+        const C = inject('store')(({ store }) => <div class="c">{ store.C }</div>);
+        const A = () => (
+            <Provider store={store}>
+                <B/>
+                <C/>
+            </Provider>
+        );
+        render(<A/>, testRoot);
+        expect(testRoot.querySelector('.b').textContent).toBe('foo');
+        expect(testRoot.querySelector('.c').textContent).toBe('bar');
+    });
 });


### PR DESCRIPTION
If this happens then they will be wrapped with a `div` element
automatically, instead of failing.